### PR TITLE
updated dependency to scraperjs

### DIFF
--- a/example.js
+++ b/example.js
@@ -1,10 +1,9 @@
 var fetchColors = require('./index.js');
-//var fetchColors = require('dribbble-colors');
 
 fetchColors('http://dribbble.com/shots/1142625-Twitter-Redesign-2013', function(err, colors) {
-	if(err) {
-		throw err;
-	}
+  if(err) {
+    throw err;
+  }
 	console.log(colors);
 	// => ['#FBFCFC', '#1F272D', '#ADB6BD', '#3B90C9', '#4B4A51', '#897E6B', '#4895CD', '#6E8E95']
 });

--- a/index.js
+++ b/index.js
@@ -1,13 +1,14 @@
-var scraper = require('scraper');
+var scraperjs = require('scraperjs');
 
 module.exports = function(url, cb) {
-	scraper(url, function(err, jQuery) {
-	    if (err) {
-	    	cb(err, null);
-	    }
 
-	    cb(null, jQuery('li.color a').map(function() {
-	        return jQuery(this).text();
-	    }));
-	});
+  scraperjs.StaticScraper.create(url)
+    .scrape(function($) {
+      return $("li.color a").map(function() {
+        return $(this).text();
+      }).get();
+    })
+    .then((colors)=> cb(null, colors))
+    .catch((err)=> cb(err));
+
 };

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Color scraper for Dribbble shots.",
   "main": "index.js",
   "dependencies": {
-    "scraper": "0.0.9"
+    "scraperjs": "1.2.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
`scraper` depended on an old version of jsdom causing this error:

```
/Users/dharness/Desktop/untitled folder 2/node_modules/scraper/lib/scraper.js:56
					var window = jsdom.jsdom().createWindow();
					                           ^

TypeError: jsdom.jsdom(...).createWindow is not a function
```

`scraper` was unsupported and lacking in documentation so I switched to the better-maintained `scraperjs`